### PR TITLE
Fixed: block duration for short Media Session

### DIFF
--- a/src/main/kotlin/io/sip3/twig/ce/service/media/MediaSessionService.kt
+++ b/src/main/kotlin/io/sip3/twig/ce/service/media/MediaSessionService.kt
@@ -117,7 +117,11 @@ open class MediaSessionService {
         }
 
         val blocks = ArrayList<MediaStatistic>(blockCount)
-        val blockDuration = legSession.duration / blockCount
+        val blockDuration = if (legSession.duration / blockCount > 0) {
+            legSession.duration / blockCount
+        } else {
+            legSession.duration
+        }
 
         var remainingDuration: Int
         var currentBlock = MediaStatistic()
@@ -141,7 +145,9 @@ open class MediaSessionService {
                 }
 
                 reportDuration > remainingDuration -> {
-                    val chunks = splitReport(report, remainingDuration, blockDuration)
+                    val chunks = mutableListOf<Document>()
+                    splitReport(chunks, report, remainingDuration, blockDuration)
+
                     val iterator = chunks.iterator()
 
                     updateMediaStatistic(currentBlock, iterator.next())

--- a/src/main/kotlin/io/sip3/twig/ce/service/media/util/ReportUtil.kt
+++ b/src/main/kotlin/io/sip3/twig/ce/service/media/util/ReportUtil.kt
@@ -21,7 +21,7 @@ import kotlin.math.roundToInt
 
 object ReportUtil {
 
-    fun splitReport(report: Document, remainingDuration: Int, blockDuration: Int): MutableList<Document> {
+    fun splitReport(chunks: MutableList<Document>, report: Document, remainingDuration: Int, blockDuration: Int) {
         val reportDuration = report.getInteger("duration")
 
         val firstFraction = remainingDuration.toDouble() / reportDuration
@@ -30,12 +30,11 @@ object ReportUtil {
         val firstReport = reduceReport(report, firstFraction)
         val remainingReport = reduceReport(report, secondFraction)
 
-        return if (remainingReport.getInteger("duration") < blockDuration) {
-            mutableListOf(firstReport, remainingReport)
+        chunks.add(firstReport)
+        if (remainingReport.getInteger("duration") <= blockDuration) {
+            chunks.add(remainingReport)
         } else {
-            mutableListOf(firstReport).apply {
-                addAll(splitReport(remainingReport, blockDuration, blockDuration))
-            }
+            splitReport(chunks, remainingReport, blockDuration, blockDuration)
         }
     }
 

--- a/src/test/kotlin/io/sip3/twig/ce/service/media/util/ReportUtilTest.kt
+++ b/src/test/kotlin/io/sip3/twig/ce/service/media/util/ReportUtilTest.kt
@@ -50,7 +50,8 @@ class ReportUtilTest {
 
     @Test
     fun `Split report`() {
-        val chunks = splitReport(RTPR_RAW, 820, 1000)
+        val chunks = mutableListOf<Document>()
+        splitReport(chunks, RTPR_RAW, 820, 1000)
         assertEquals(6, chunks.size)
         assertEquals(820, chunks.first().getInteger("duration"))
         assertEquals(300, chunks.last().getInteger("duration"))


### PR DESCRIPTION
Modified: `ReportUtil.splitReport()` refactoring