### PR TITLE
Added: `session.ignore-nanos` to configuration

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,6 +45,7 @@ session:
   default-limit: 50
   use-x-correlation-header: true
   show-retransmits: true
+  ignore-nanos: true
   call:
     max-legs: 10
     aggregation-timeout: 60000


### PR DESCRIPTION
Modified: Sort by nanos if `created_at` equals now is optional